### PR TITLE
Feature: Handling vulnerabilities when merging BOM

### DIFF
--- a/src/CycloneDX.Utils/Merge.cs
+++ b/src/CycloneDX.Utils/Merge.cs
@@ -165,7 +165,10 @@ namespace CycloneDX.Utils
 
                 var thisComponent = bom.Metadata.Component;
                 if (thisComponent.Components is null) bom.Metadata.Component.Components = new List<Component>();
-                if (!(bom.Components is null)) thisComponent.Components.AddRange(bom.Components);
+                if (!(bom.Components is null))
+                {
+                    thisComponent.Components.AddRange(bom.Components);
+                }
 
                 // add a namespace to existing BOM refs
                 NamespaceComponentBomRefs(thisComponent);
@@ -278,9 +281,11 @@ namespace CycloneDX.Utils
                 vulnerability.BomRef = NamespacedBomRef(bomRefNamespace, vulnerability.BomRef);
 
                 if (vulnerability.Affects != null)
-                foreach (var affect in vulnerability.Affects)
                 {
-                    affect.Ref = bomRefNamespace;
+                    foreach (var affect in vulnerability.Affects)
+                    {
+                        affect.Ref = bomRefNamespace;
+                    }
                 }
             }
         }

--- a/src/CycloneDX.Utils/Merge.cs
+++ b/src/CycloneDX.Utils/Merge.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Collections.Generic;
 using CycloneDX.Models;
+using CycloneDX.Models.Vulnerabilities;
 using CycloneDX.Utils.Exceptions;
 
 namespace CycloneDX.Utils
@@ -80,6 +81,9 @@ namespace CycloneDX.Utils
             var compositionsMerger = new ListMergeHelper<Composition>();
             result.Compositions = compositionsMerger.Merge(bom1.Compositions, bom2.Compositions);
 
+            var vulnerabilitiesMerger = new ListMergeHelper<Vulnerability>();
+            result.Vulnerabilities = vulnerabilitiesMerger.Merge(bom1.Vulnerabilities, bom2.Vulnerabilities);
+
             return result;
         }
 
@@ -140,6 +144,7 @@ namespace CycloneDX.Utils
             result.ExternalReferences = new List<ExternalReference>();
             result.Dependencies = new List<Dependency>();
             result.Compositions = new List<Composition>();
+            result.Vulnerabilities = new List<Vulnerability>();
 
             var bomSubjectDependencies = new List<Dependency>();
 
@@ -160,7 +165,7 @@ namespace CycloneDX.Utils
 
                 var thisComponent = bom.Metadata.Component;
                 if (thisComponent.Components is null) bom.Metadata.Component.Components = new List<Component>();
-                thisComponent.Components.AddRange(bom.Components);
+                if (!(bom.Components is null)) thisComponent.Components.AddRange(bom.Components);
 
                 // add a namespace to existing BOM refs
                 NamespaceComponentBomRefs(thisComponent);
@@ -196,6 +201,13 @@ namespace CycloneDX.Utils
                     NamespaceCompositions(ComponentBomRefNamespace(bom.Metadata.Component), bom.Compositions);
                     result.Compositions.AddRange(bom.Compositions);
                 }
+
+                // vulnerabilities
+                if (bom.Vulnerabilities != null)
+                {
+                    NamespaceVulnerabilitiesRefs(ComponentBomRefNamespace(result.Metadata.Component), bom.Vulnerabilities);
+                    result.Vulnerabilities.AddRange(bom.Vulnerabilities);
+                }
             }
 
             if (bomSubject != null)
@@ -214,6 +226,7 @@ namespace CycloneDX.Utils
             if (result.ExternalReferences.Count == 0) result.ExternalReferences = null;
             if (result.Dependencies.Count == 0) result.Dependencies = null;
             if (result.Compositions.Count == 0) result.Compositions = null;
+            if (result.Vulnerabilities.Count == 0) result.Vulnerabilities = null;
 
             return result;
         }
@@ -251,6 +264,24 @@ namespace CycloneDX.Utils
                 }
 
                 currentComponent.BomRef = NamespacedBomRef(topComponent, currentComponent.BomRef);
+            }
+        }
+
+        private static void NamespaceVulnerabilitiesRefs(string bomRefNamespace, List<Vulnerability> vulnerabilities)
+        {
+            var pendingVulnerabilities = new Stack<Vulnerability>(vulnerabilities);
+
+            while (pendingVulnerabilities.Count > 0)
+            {
+                var vulnerability = pendingVulnerabilities.Pop();
+
+                vulnerability.BomRef = NamespacedBomRef(bomRefNamespace, vulnerability.BomRef);
+
+                if (vulnerability.Affects != null)
+                foreach (var affect in vulnerability.Affects)
+                {
+                    affect.Ref = bomRefNamespace;
+                }
             }
         }
 

--- a/tests/CycloneDX.Utils.Tests/MergeTests.cs
+++ b/tests/CycloneDX.Utils.Tests/MergeTests.cs
@@ -22,6 +22,7 @@ using Snapshooter;
 using Snapshooter.Xunit;
 using CycloneDX;
 using CycloneDX.Models;
+using CycloneDX.Models.Vulnerabilities;
 using CycloneDX.Utils;
 
 namespace CycloneDX.Utils.Tests
@@ -87,6 +88,49 @@ namespace CycloneDX.Utils.Tests
                     {
                         Name = "Component2",
                         Version = "1"
+                    }
+                }
+            };
+
+            var result = CycloneDXUtils.FlatMerge(sbom1, sbom2);
+
+            Snapshot.Match(result);
+        }
+
+        [Fact]
+        public void FlatMergeVulnerabilitiesTest()
+        {
+            var sbom1 = new Bom
+            {
+                Vulnerabilities = new List<Vulnerability>
+                {
+                    new Vulnerability
+                    {
+                        Id = "cve1",
+                        Affects = new List<Affects>
+                        {
+                            new Affects
+                            {
+                                Ref = "ref1"
+                            }
+                        }
+                    }
+                }
+            };
+            var sbom2 = new Bom
+            {
+                Vulnerabilities = new List<Vulnerability>
+                {
+                    new Vulnerability
+                    {
+                        Id = "cve2",
+                        Affects = new List<Affects>
+                        {
+                            new Affects
+                            {
+                                Ref = "ref2"
+                            }
+                        }
                     }
                 }
             };
@@ -201,6 +245,73 @@ namespace CycloneDX.Utils.Tests
                         Dependencies = new List<string>
                         {
                             "System2@1"
+                        }
+                    }
+                }
+            };
+
+            var result = CycloneDXUtils.HierarchicalMerge(new [] { sbom1, sbom2 }, subject);
+
+            Snapshot.Match(result);
+        }
+
+        [Fact]
+        public void HierarchicalMergeVulnerabilitiesTest()
+        {
+            var subject = new Component
+            {
+                Name = "Thing",
+                Version = "1",
+            };
+
+            var sbom1 = new Bom
+            {
+                Metadata = new Metadata
+                {
+                    Component = new Component
+                    {
+                        Name = "System1",
+                        Version = "1",
+                        BomRef = "System1@1"
+                    }
+                },
+                Vulnerabilities = new List<Vulnerability>
+                {
+                    new Vulnerability
+                    {
+                        Id = "cve1",
+                        Affects = new List<Affects>
+                        {
+                            new Affects
+                            {
+                                Ref = "ref1"
+                            }
+                        }
+                    }
+                }
+            };
+            var sbom2 = new Bom
+            {
+                Metadata = new Metadata
+                {
+                    Component = new Component
+                    {
+                        Name = "System2",
+                        Version = "1",
+                        BomRef = "System2@1"
+                    }
+                },
+                Vulnerabilities = new List<Vulnerability>
+                {
+                    new Vulnerability
+                    {
+                        Id = "cve2",
+                        Affects = new List<Affects>
+                        {
+                            new Affects
+                            {
+                                Ref = "ref2"
+                            }
                         }
                     }
                 }

--- a/tests/CycloneDX.Utils.Tests/__snapshots__/MergeTests.FlatMergeVulnerabilitiesTest.snap
+++ b/tests/CycloneDX.Utils.Tests/__snapshots__/MergeTests.FlatMergeVulnerabilitiesTest.snap
@@ -1,0 +1,54 @@
+﻿{
+  "BomFormat": "CycloneDX",
+  "SpecVersion": "v1_4",
+  "SpecVersionString": "1.4",
+  "SerialNumber": null,
+  "Version": null,
+  "Metadata": null,
+  "Components": null,
+  "Compositions": null,
+  "Vulnerabilities": [
+    {
+      "BomRef": null,
+      "Id": "cve1",
+      "Source": null,
+      "References": null,
+      "Ratings": null,
+      "CWES": null,
+      "Description": null,
+      "Detail": null,
+      "Recommendation": null,
+      "Advisories": null,
+      "Credits": null,
+      "Tools": null,
+      "Analysis": null,
+      "Affects": [
+        {
+          "Ref": "ref1",
+          "Range": null
+        }
+      ]
+    },
+    {
+      "BomRef": null,
+      "Id": "cve2",
+      "Source": null,
+      "References": null,
+      "Ratings": null,
+      "CWES": null,
+      "Description": null,
+      "Detail": null,
+      "Recommendation": null,
+      "Advisories": null,
+      "Credits": null,
+      "Tools": null,
+      "Analysis": null,
+      "Affects": [
+        {
+          "Ref": "ref2",
+          "Range": null
+        }
+      ]
+    }
+  ]
+}

--- a/tests/CycloneDX.Utils.Tests/__snapshots__/MergeTests.HierarchicalMergeVulnerabilitiesTest.snap
+++ b/tests/CycloneDX.Utils.Tests/__snapshots__/MergeTests.HierarchicalMergeVulnerabilitiesTest.snap
@@ -1,0 +1,144 @@
+﻿{
+  "BomFormat": "CycloneDX",
+  "SpecVersion": "v1_4",
+  "SpecVersionString": "1.4",
+  "SerialNumber": null,
+  "Version": null,
+  "Metadata": {
+    "Tools": null,
+    "Authors": null,
+    "Component": {
+      "Type": "Null",
+      "MimeType": null,
+      "BomRef": "Thing@1",
+      "Supplier": null,
+      "Author": null,
+      "Publisher": null,
+      "Group": null,
+      "Name": "Thing",
+      "Version": "1",
+      "Description": null,
+      "Scope": null,
+      "Hashes": null,
+      "Licenses": null,
+      "Copyright": null,
+      "Cpe": null,
+      "Purl": null,
+      "Swid": null,
+      "Modified": null,
+      "Pedigree": null,
+      "Components": null,
+      "Evidence": null
+    },
+    "Manufacture": null,
+    "Supplier": null
+  },
+  "Components": [
+    {
+      "Type": "Null",
+      "MimeType": null,
+      "BomRef": "System1@1:System1@1",
+      "Supplier": null,
+      "Author": null,
+      "Publisher": null,
+      "Group": null,
+      "Name": "System1",
+      "Version": "1",
+      "Description": null,
+      "Scope": null,
+      "Hashes": null,
+      "Licenses": null,
+      "Copyright": null,
+      "Cpe": null,
+      "Purl": null,
+      "Swid": null,
+      "Modified": null,
+      "Pedigree": null,
+      "Components": [],
+      "Evidence": null
+    },
+    {
+      "Type": "Null",
+      "MimeType": null,
+      "BomRef": "System2@1:System2@1",
+      "Supplier": null,
+      "Author": null,
+      "Publisher": null,
+      "Group": null,
+      "Name": "System2",
+      "Version": "1",
+      "Description": null,
+      "Scope": null,
+      "Hashes": null,
+      "Licenses": null,
+      "Copyright": null,
+      "Cpe": null,
+      "Purl": null,
+      "Swid": null,
+      "Modified": null,
+      "Pedigree": null,
+      "Components": [],
+      "Evidence": null
+    }
+  ],
+  "Dependencies": [
+    {
+      "Ref": "Thing@1",
+      "Dependencies": [
+        {
+          "Ref": "System1@1:System1@1",
+          "Dependencies": null
+        },
+        {
+          "Ref": "System2@1:System2@1",
+          "Dependencies": null
+        }
+      ]
+    }
+  ],
+  "Compositions": null,
+  "Vulnerabilities": [
+    {
+      "BomRef": null,
+      "Id": "cve1",
+      "Source": null,
+      "References": null,
+      "Ratings": null,
+      "CWES": null,
+      "Description": null,
+      "Detail": null,
+      "Recommendation": null,
+      "Advisories": null,
+      "Credits": null,
+      "Tools": null,
+      "Analysis": null,
+      "Affects": [
+        {
+          "Ref": "Thing@1",
+          "Range": null
+        }
+      ]
+    },
+    {
+      "BomRef": null,
+      "Id": "cve2",
+      "Source": null,
+      "References": null,
+      "Ratings": null,
+      "CWES": null,
+      "Description": null,
+      "Detail": null,
+      "Recommendation": null,
+      "Advisories": null,
+      "Credits": null,
+      "Tools": null,
+      "Analysis": null,
+      "Affects": [
+        {
+          "Ref": "Thing@1",
+          "Range": null
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add VEX support to both flat and hierarchical merging use cases (#165).

Signed-off-by: Alioune SY <sy_alioune@yahoo.fr>

Regarding hierarchical merge, the `vulnerabilities[*].affects[*].ref` is set to the top level `bomSubject`