### PR TITLE
fix issues with duplicates and missing main components

### DIFF
--- a/src/CycloneDX.Core/Models/Component.cs
+++ b/src/CycloneDX.Core/Models/Component.cs
@@ -27,7 +27,7 @@ namespace CycloneDX.Models
     [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
     [XmlType("component")]
     [ProtoContract]
-    public class Component
+    public class Component: IEquatable<Component>
     {
         [ProtoContract]
         public enum Classification
@@ -196,5 +196,11 @@ namespace CycloneDX.Models
         [ProtoMember(24)]
         public ReleaseNotes ReleaseNotes { get; set; }
         public bool ShouldSerializeReleaseNotes() { return ReleaseNotes != null; }
+
+        public bool Equals(Component obj)
+        {
+            return (BomRef != null && BomRef.Equals(obj.BomRef)) || 
+            (Group == obj.Group && Name == obj.Name && Version == obj.Version);
+        }
     }
 }

--- a/src/CycloneDX.Core/Models/Dependency.cs
+++ b/src/CycloneDX.Core/Models/Dependency.cs
@@ -26,7 +26,7 @@ namespace CycloneDX.Models
 {
     [XmlType("dependency")]
     [ProtoContract]
-    public class Dependency
+    public class Dependency: IEquatable<Dependency>
     {
         [XmlAttribute("ref")]
         [ProtoMember(1)]
@@ -35,5 +35,10 @@ namespace CycloneDX.Models
         [XmlElement("dependency")]
         [ProtoMember(2)]
         public List<Dependency> Dependencies { get; set; }
+
+        public bool Equals(Dependency other)
+        {
+            return Ref.Equals(other.Ref);
+        }
     }
 }

--- a/src/CycloneDX.Core/Models/Service.cs
+++ b/src/CycloneDX.Core/Models/Service.cs
@@ -24,7 +24,7 @@ using ProtoBuf;
 namespace CycloneDX.Models
 {
     [ProtoContract]
-    public class Service
+    public class Service: IEquatable<Service>
     {
         [XmlAttribute("bom-ref")]
         [JsonPropertyName("bom-ref")]
@@ -123,5 +123,10 @@ namespace CycloneDX.Models
         [XmlArrayItem("property")]
         [ProtoMember(14)]
         public List<Property> Properties { get; set; }
+
+        public bool Equals(Service obj)
+        {
+            return  BomRef.Equals(obj.BomRef);
+        }
     }
 }

--- a/src/CycloneDX.Core/Models/Tool.cs
+++ b/src/CycloneDX.Core/Models/Tool.cs
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) OWASP Foundation. All Rights Reserved.
 
+using System;
 using System.Collections.Generic;
 using System.Xml.Serialization;
 using ProtoBuf;
@@ -22,7 +23,7 @@ using ProtoBuf;
 namespace CycloneDX.Models
 {
     [ProtoContract]
-    public class Tool
+    public class Tool: IEquatable<Tool>
     {
         [XmlElement("vendor")]
         [ProtoMember(1)]
@@ -45,5 +46,10 @@ namespace CycloneDX.Models
         [ProtoMember(5)]
         public List<ExternalReference> ExternalReferences { get; set; }
         public bool ShouldSerializeExternalReferences() { return ExternalReferences?.Count > 0; }
+
+        public bool Equals(Tool obj)
+        {
+            return Vendor == obj.Vendor && Name == obj.Name && Version == obj.Version;
+        }
     }
 }

--- a/src/CycloneDX.Core/Models/Vulnerabilities/Vulnerability.cs
+++ b/src/CycloneDX.Core/Models/Vulnerabilities/Vulnerability.cs
@@ -24,7 +24,7 @@ using ProtoBuf;
 namespace CycloneDX.Models.Vulnerabilities
 {
     [ProtoContract]
-    public class Vulnerability
+    public class Vulnerability: IEquatable<Vulnerability>
     {
         [XmlAttribute("bom-ref")]
         [JsonPropertyName("bom-ref")]
@@ -124,5 +124,10 @@ namespace CycloneDX.Models.Vulnerabilities
         [ProtoMember(18)]
         public List<Property> Properties { get; set; }
         public bool ShouldSerializeProperties() { return Properties?.Count > 0; }
+
+        public bool Equals(Vulnerability obj)
+        {
+            return  BomRef.Equals(obj.BomRef);
+        }
     }
 }

--- a/src/CycloneDX.Core/Models/Vulnerabilities/Vulnerability.cs
+++ b/src/CycloneDX.Core/Models/Vulnerabilities/Vulnerability.cs
@@ -127,7 +127,7 @@ namespace CycloneDX.Models.Vulnerabilities
 
         public bool Equals(Vulnerability obj)
         {
-            return  BomRef.Equals(obj.BomRef);
+            return  Id.Equals(obj.Id);
         }
     }
 }

--- a/src/CycloneDX.Utils/Merge.cs
+++ b/src/CycloneDX.Utils/Merge.cs
@@ -77,7 +77,7 @@ namespace CycloneDX.Utils
             result.Components = componentsMerger.Merge(bom1.Components, bom2.Components);
 
             //Add main component if missing
-            if (!(bom2.Metadata?.Component is null) && !result.Components.Contains(bom2.Metadata.Component)) 
+            if (result.Components != null && !(bom2.Metadata?.Component is null) && !result.Components.Contains(bom2.Metadata.Component)) 
             {
                 result.Components.Add(bom2.Metadata.Component);
             }


### PR DESCRIPTION
Flatten Merge duplicates all the components/dependencies and skips the main component on metadata.
when merging the dependencies the graph is also broken because there isn't a connection with the boms main components

Fixes https://github.com/CycloneDX/cyclonedx-cli/issues/219
Fixes https://github.com/CycloneDX/cyclonedx-cli/issues/188