### PR TITLE
Json/Validator: add findNamedElements() to detect duplicate "bom-ref" definitions

### DIFF
--- a/src/CycloneDX.Core/Json/Validator.cs
+++ b/src/CycloneDX.Core/Json/Validator.cs
@@ -166,6 +166,88 @@ namespace CycloneDX.Json
             }
         }
 
+        private static Dictionary<JsonElement, List<JsonElement>> addDictList(
+            Dictionary<JsonElement, List<JsonElement>> dict1,
+            Dictionary<JsonElement, List<JsonElement>> dict2)
+        {
+            if (dict2 == null || dict2.Count == 0)
+            {
+                return dict1;
+            }
+
+            if (dict1 == null || dict1.Count == 0)
+            {
+                return dict2;
+            }
+
+            foreach (KeyValuePair<JsonElement, List<JsonElement>> KVP in dict2)
+            {
+                if (dict1.ContainsKey(KVP.Key))
+                {
+                    dict1[KVP.Key].AddRange(KVP.Value);
+                }
+                else
+                {
+                    dict1.Add(KVP.Key, KVP.Value);
+                }
+            }
+
+            return dict1;
+        }
+
+        /// <summary>
+        /// Iterate through the JSON document to find JSON objects whose property names
+        /// match the one we seek, and add such hits to returned list. Recurse and repeat.
+        /// </summary>
+        /// <param name="element">A JsonElement, starting from JsonDocument.RootElement
+        ///    for the original caller, probably. Then used to recurse.
+        /// </param>
+        /// <param name="name">The property name we seek.</param>
+        /// <returns>A Dictionary with distinct values of the seeked JsonElement as keys,
+        ///    and a List of "parent" JsonElement (which contain such key) as mapped values.
+        /// </returns>
+        private static Dictionary<JsonElement, List<JsonElement>> findNamedElements(JsonElement element, string name)
+        {
+            Dictionary<JsonElement, List<JsonElement>> hits = new Dictionary<JsonElement, List<JsonElement>>();
+            Dictionary<JsonElement, List<JsonElement>> nestedHits = null;
+
+            // Can we iterate further?
+            switch (element.ValueKind) {
+                case JsonValueKind.Object:
+                    foreach (JsonProperty property in element.EnumerateObject())
+                    {
+                        if (property.Name == name) {
+                            if (!hits.ContainsKey(property.Value))
+                            {
+                                hits.Add(property.Value, new List<JsonElement>());
+                            }
+                            hits[property.Value].Add(element);
+                        }
+
+                        // Note: Here we can recurse into same property that
+                        // we've just listed, if it is not of a simple kind.
+                        nestedHits = findNamedElements(property.Value, name);
+                        hits = addDictList(hits, nestedHits);
+                    }
+                    break;
+
+                case JsonValueKind.Array:
+                    foreach (JsonElement nestedElem in element.EnumerateArray())
+                    {
+                        nestedHits = findNamedElements(nestedElem, name);
+                        hits = addDictList(hits, nestedHits);
+                    }
+                    break;
+
+                default:
+                    // No-op for simple types: these values per se have no name
+                    // to learn, and we can not iterate deeper into them.
+                    break;
+            }
+
+            return hits;
+        }
+
         private static ValidationResult Validate(JsonSchema schema, JsonDocument jsonDocument, string schemaVersionString)
         {
             var validationMessages = new List<string>();
@@ -188,6 +270,23 @@ namespace CycloneDX.Json
                         {
                             validationMessages.Add($"Incorrect schema version: expected {schemaVersionString} actual {specVersion}");
                         }
+                    }
+                }
+
+                // The JSON Schema, at least the ones defined by CycloneDX
+                // and handled by current parser in dotnet ecosystem, can
+                // not specify or check the uniqueness requirement for the
+                // "bom-ref" assignments in the overall document (e.g. in
+                // "metadata/component" and list of "components", as well
+                // as in "services" and "vulnerabilities", as of CycloneDX
+                // spec v1.4), so this is checked separately here if the
+                // document seems structurally intact otherwise.
+                // Note that this is not a problem for the XML schema with
+                // its explicit <xs:unique name="bom-ref"> constraint.
+                Dictionary<JsonElement, List<JsonElement>> bomRefs = findNamedElements(jsonDocument.RootElement, "bom-ref");
+                foreach (KeyValuePair<JsonElement, List<JsonElement>> KVP in bomRefs) {
+                    if (KVP.Value != null && KVP.Value.Count != 1) {
+                        validationMessages.Add($"'bom-ref' value of {KVP.Key.GetString()}: expected 1 mention, actual {KVP.Value.Count}");
                     }
                 }
             }


### PR DESCRIPTION
As discussed on Slack, I found that for JSON SBOMs the `cyclonedx-cli validate` does not complain about resulting document from `cyclonedx-cli merge` (which has lots of duplicate "bom-ref" entities). Conversion of that document to XML and validating the result does rightfully fail.

The PR below should hopefully fix this, but please note these are my first steps in C# and I have no idea how to force my `cyclonedx-cli` utility to actually build against the custom dll/nupkg created from this codebase. I guess I won't know until this is merged and released :(