### PR TITLE
Bom: initialize its own metadata

### DIFF
--- a/src/CycloneDX.Core/Models/Bom.cs
+++ b/src/CycloneDX.Core/Models/Bom.cs
@@ -205,15 +205,20 @@ namespace CycloneDX.Models
                 this.Metadata = new Metadata();
             }
 
-            if (this.Metadata.Tools is null)
+            if (this.Metadata.Tools is null || this.Metadata.Tools.Tools is null)
             {
-                this.Metadata.Tools = new List<Tool>(new [] {toolThisLibrary});
+                #pragma warning disable 618
+                this.Metadata.Tools = new ToolChoices
+                {
+                    Tools = new List<Tool>(new [] {toolThisLibrary}),
+                }
+                #pragma warning restore 618
             }
             else
             {
-                if (!this.Metadata.Tools.Contains(toolThisLibrary))
+                if (!this.Metadata.Tools.Tools.Contains(toolThisLibrary))
                 {
-                    this.Metadata.Tools.Add(toolThisLibrary);
+                    this.Metadata.Tools.Tools.Add(toolThisLibrary);
                 }
             }
 
@@ -228,9 +233,9 @@ namespace CycloneDX.Models
                     Version = Assembly.GetEntryAssembly().GetName().Version.ToString()
                 };
 
-                if (!this.Metadata.Tools.Contains(toolThisScript))
+                if (!this.Metadata.Tools.Tools.Contains(toolThisScript))
                 {
-                    this.Metadata.Tools.Add(toolThisScript);
+                    this.Metadata.Tools.Tools.Add(toolThisScript);
                 }
             }
         }

--- a/src/CycloneDX.Core/Models/Bom.cs
+++ b/src/CycloneDX.Core/Models/Bom.cs
@@ -269,12 +269,13 @@ namespace CycloneDX.Models
         /// </summary>
         public void BomMetadataUpdateSerialNumberVersion(bool generateNewSerialNumber)
         {
+            bool doGenerateNewSerialNumber = generateNewSerialNumber;
             if (this.Version is null || this.Version < 1 || this.SerialNumber is null || this.SerialNumber == "")
             {
-                generateNewSerialNumber = true;
+                doGenerateNewSerialNumber = true;
             }
 
-            if (generateNewSerialNumber)
+            if (doGenerateNewSerialNumber)
             {
                 this.Version = 1;
                 this.SerialNumber = "urn:uuid:" + System.Guid.NewGuid().ToString();

--- a/src/CycloneDX.Core/Models/Bom.cs
+++ b/src/CycloneDX.Core/Models/Bom.cs
@@ -193,12 +193,14 @@ namespace CycloneDX.Models
             // get the assembly your project started with (most likely
             // this is your app). In multi-project solutions this is
             // something to keep in mind!
+            #pragma warning disable 618
             Tool toolThisLibrary = new Tool
             {
                 Vendor = "OWASP Foundation",
                 Name = Assembly.GetExecutingAssembly().GetName().Name, // "cyclonedx-dotnet-library"
                 Version = Assembly.GetExecutingAssembly().GetName().Version.ToString()
             };
+            #pragma warning restore 618
 
             if (this.Metadata is null)
             {
@@ -211,7 +213,7 @@ namespace CycloneDX.Models
                 this.Metadata.Tools = new ToolChoices
                 {
                     Tools = new List<Tool>(new [] {toolThisLibrary}),
-                }
+                };
                 #pragma warning restore 618
             }
             else
@@ -226,12 +228,14 @@ namespace CycloneDX.Models
             string toolThisScriptName = Assembly.GetEntryAssembly().GetName().Name; // "cyclonedx-cli" or similar
             if (toolThisScriptName != toolThisLibrary.Name)
             {
+                #pragma warning disable 618
                 Tool toolThisScript = new Tool
                 {
                     Name = toolThisScriptName,
                     Vendor = (toolThisScriptName.ToLowerInvariant().StartsWith("cyclonedx") ? "OWASP Foundation" : null),
                     Version = Assembly.GetEntryAssembly().GetName().Version.ToString()
                 };
+                #pragma warning restore 618
 
                 if (!this.Metadata.Tools.Tools.Contains(toolThisScript))
                 {

--- a/src/CycloneDX.Utils/Merge.cs
+++ b/src/CycloneDX.Utils/Merge.cs
@@ -140,6 +140,11 @@ namespace CycloneDX.Utils
         public static Bom FlatMerge(IEnumerable<Bom> boms, Component bomSubject)
         {
             var result = new Bom();
+            // New resulting Bom has its own identity (timestamp, serial)
+            // and its Tools collection refers to this library and the
+            // tool which consumes it.
+            result.BomMetadataUpdate(true);
+            result.BomMetadataReferThisToolkit();
             
             foreach (var bom in boms)
             {
@@ -192,19 +197,16 @@ namespace CycloneDX.Utils
         public static Bom HierarchicalMerge(IEnumerable<Bom> boms, Component bomSubject)
         {
             var result = new Bom();
+            // New resulting Bom has its own identity (timestamp, serial)
+            // and its Tools collection refers to this library and the
+            // tool which consumes it.
+            result.BomMetadataUpdate(true);
+            result.BomMetadataReferThisToolkit();
+
             if (bomSubject != null)
             {
                 if (bomSubject.BomRef is null) bomSubject.BomRef = ComponentBomRefNamespace(bomSubject);
-                result.Metadata = new Metadata
-                {
-                    Component = bomSubject,
-                    #pragma warning disable 618
-                    Tools = new ToolChoices
-                    {
-                        Tools = new List<Tool>(),
-                    }
-                    #pragma warning restore 618
-                };
+                result.Metadata.Component = bomSubject;
             }
 
             result.Components = new List<Component>();


### PR DESCRIPTION
This PR is yet another part of my larger proposal of Merge ability changes stacked in the PR queue.

It adds some utility methods to `Bom` class, so it can be in charge of initializing a (usually `new`) Bom object into a usefully populated one, e.g. the merge `result` to pile other Bom's into, while being the authoritative location to know and care about the class and data structure involved - well in OOP style.

These methods allow the `Bom` object to initialize:
* a Metadata object (if null);
* a collection of `Metadata/Tools` (now updated to match recent changes in upstream code of the library with a `ToolChoices` layer) pre-populated with the current version of the `cyclonedx-dotnet-library` and if possible to discover - its consumer like the `cyclonedx-cli` tool;
* a timestamp (now);
* either a new serial number (new UUIDv4) and set `Version=1` if this is a new document (or if explicitly requested by method argument), or increment the `Version` field if it is a re-iteration of an existing document.

Library consumers which modify these fields directly (e.g. `MergeCommand.cs` in `cyclonedx-cli`) would benefit from being updated accordingly; a PR to this effect will be posted shortly.

Calls to these methods were added to `HierarchicalMerge()` and `FlatMerge(Boms, ...)` methods, to pre-populate the `result` object into which merged information would land, since after any processing we conceptually yield a new document.

Note that it would be pedantically prudent to also do this in `FlatMerge(Bom, Bom)` method which does most of the actual merging work - however, it does so in a loop (called from `FlatMerge(Boms, ...)`) and in current `Merge.cs` codebase would just waste CPU time on detection or generation of needed information just to forget it with the next cycle. Still, it would be "correct" to populate this information for the benefit of (theoretically possible, not seen yet) "other consumers" who would only call this method directly, and not know/care about populating those fields on their own, whether "manually" or by using the `Bom` methods introduced here on the object that pops out from the `FlatMerge()` call. I did not pursue this corner case here, because it is addressed differently (with an API change to pass toggles whether to do or skip such pre-init) in the larger solution for merge ability improvements.

As it happens, this PR also fixes an issue reported earlier:
Closes: #183