### PR TITLE
Fix ScoreMethod.CVSSV31 serialization

### DIFF
--- a/src/CycloneDX.Core/Json/Converters/ScoreMethodConverter.cs
+++ b/src/CycloneDX.Core/Json/Converters/ScoreMethodConverter.cs
@@ -61,10 +61,6 @@ namespace CycloneDX.Json.Converters
             {
                 writer.WriteStringValue("other");
             }
-            else if (value == ScoreMethod.CVSSV31)
-            {
-                writer.WriteStringValue("CVSSv3.1");
-            }
             else if (value.ToString().StartsWith("CVSSV"))
             {
                 writer.WriteStringValue("CVSSv" + value.ToString().Substring(5));

--- a/src/CycloneDX.Core/Models/Vulnerabilities/ScoreMethod.cs
+++ b/src/CycloneDX.Core/Models/Vulnerabilities/ScoreMethod.cs
@@ -30,7 +30,7 @@ namespace CycloneDX.Models.Vulnerabilities
         CVSSV2,
         [XmlEnum(Name = "CVSSv3")]
         CVSSV3,
-        [XmlEnum(Name = "CVSSv3.1")]
+        [XmlEnum(Name = "CVSSv31")]
         CVSSV31,
         [XmlEnum(Name = "OWASP")]
         OWASP,


### PR DESCRIPTION
The CycloneDX schema for both JSON and XML defines the possible values for the field that uses ScoreMethod as its type:

https://cyclonedx.org/docs/1.5/json/#vulnerabilities_items_ratings_items_method
https://cyclonedx.org/docs/1.5/xml/#type_scoreSourceType

In both of these cases the correct representation of CVSS v3.1 seems to be the string "CVSSv31". For some reason, the library serializes this as "CVSSv3.1", and thus generated files fail schema validation.