### PR TITLE
Update JsonSchema.Net to 5.3.0 to get access to higher precision timestamp support

### DIFF
--- a/src/CycloneDX.Core/CycloneDX.Core.csproj
+++ b/src/CycloneDX.Core/CycloneDX.Core.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="JsonSchema.Net" Version="3.3.2" />
+    <PackageReference Include="JsonSchema.Net" Version="5.3.0" />
     <PackageReference Include="protobuf-net" Version="3.2.26" />
     <PackageReference Include="protobuf-net.BuildTools" Version="3.2.12" PrivateAssets="all" IncludeAssets="runtime;build;native;contentfiles;analyzers;buildtransitive" />
     <PackageReference Include="System.Text.Json" Version="7.0.2" />

--- a/src/CycloneDX.Spdx/CycloneDX.Spdx.csproj
+++ b/src/CycloneDX.Spdx/CycloneDX.Spdx.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="JsonSchema.Net" Version="3.3.2" />
+    <PackageReference Include="JsonSchema.Net" Version="5.3.0" />
     <PackageReference Include="System.Text.Json" Version="7.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Maybe /fixes #265 