### PR TITLE
Fix tools serialization (for versions < 1.5)

### DIFF
--- a/src/CycloneDX.Core/Json/Converters/ToolChoicesConverter.cs
+++ b/src/CycloneDX.Core/Json/Converters/ToolChoicesConverter.cs
@@ -73,12 +73,15 @@ namespace CycloneDX.Json.Converters
             Contract.Requires(writer != null);
             Contract.Requires(value != null);
 
-            if (value.Tools != null)
+            if (value.Tools != null || value.SpecVersion < SpecificationVersion.v1_5)
             {
                 writer.WriteStartArray();
-                foreach (var tool in value.Tools)
+                if (value.Tools != null)
                 {
-                    JsonSerializer.Serialize(writer, tool, options);
+                    foreach (var tool in value.Tools)
+                    {
+                        JsonSerializer.Serialize(writer, tool, options);
+                    }
                 }
                 writer.WriteEndArray();
             }

--- a/tests/CycloneDX.Core.Tests/Json/v1.5/SerializationTests.cs
+++ b/tests/CycloneDX.Core.Tests/Json/v1.5/SerializationTests.cs
@@ -162,9 +162,7 @@ namespace CycloneDX.Core.Tests.Json.v1_5
         [InlineData("valid-service-1.5.json")]
         [InlineData("valid-service-empty-objects-1.5.json")]
         [InlineData("valid-signatures-1.5.json")]
-        //TODO - I do not know why this particular one is failing
-        //Validating it with other tools works, maybe an obscure STJ bug???
-        //[InlineData("valid-vulnerability-1.5.json")]
+        [InlineData("valid-vulnerability-1.5.json")]
         public void JsonDowngradeTest(string filename)
         {
             var resourceFilename = Path.Join("Resources", "v1.5", filename);


### PR DESCRIPTION
Fix tools serialization (for versions < 1.5)

According to
https://cyclonedx.org/docs/1.4/json/#vulnerabilities_items_tools
tools needs to be an array, not a null value.