### PR TITLE
Convert a SPDX purl externalReference into the item level purl field

### DIFF
--- a/src/CycloneDX.Spdx.Interop/Converters/v2_3/Helpers/Component/ExternalRefs.cs
+++ b/src/CycloneDX.Spdx.Interop/Converters/v2_3/Helpers/Component/ExternalRefs.cs
@@ -142,12 +142,15 @@ namespace CycloneDX.Spdx.Interop.Helpers
                         {
                             refPropValue = $"{extRef.ReferenceLocator} {extRef.Comment}";
                         }
-                        component.Properties.AddSpdxElement(refPropName, refPropValue);
 
-                        if (refPropName == PropertyTaxonomy.EXTERNAL_REFERENCE_PACKAGE_MANAGER_PURL)
+                        if (refPropName == PropertyTaxonomy.EXTERNAL_REFERENCE_PACKAGE_MANAGER_PURL && component.Purl == null)
                         {
+                            // For the first seen purl, assume it is the component's purl.
                             component.Purl = refPropValue;
+                            continue;
                         }
+
+                        component.Properties.AddSpdxElement(refPropName, refPropValue);
                     }
                 }
             }

--- a/src/CycloneDX.Spdx.Interop/Converters/v2_3/Helpers/SpdxDocumentHelpers.cs
+++ b/src/CycloneDX.Spdx.Interop/Converters/v2_3/Helpers/SpdxDocumentHelpers.cs
@@ -200,6 +200,23 @@ namespace CycloneDX.Spdx.Interop.Helpers
                 package.Checksums = component.GetSpdxChecksums();
                 package.ExternalRefs = component.GetSpdxExternalRefs();
 
+                if (component.Purl != null)
+                {
+                    if (package.ExternalRefs == null)
+                    {
+                        package.ExternalRefs = new List<ExternalRef>();
+                    }
+
+                    // Insert at the start, so that this correctly roundtrips, i.e. if there are
+                    // multiple PURLs, always pick the first as the component's PURL.
+                    package.ExternalRefs.Insert(0, new ExternalRef
+                    {
+                        ReferenceCategory = ExternalRefCategory.PACKAGE_MANAGER,
+                        ReferenceType = "purl",
+                        ReferenceLocator = component.Purl,
+                    });
+                }
+
                 package.DownloadLocation = component.Properties?.GetSpdxElement(PropertyTaxonomy.DOWNLOAD_LOCATION) ?? "NOASSERTION";
                 package.Homepage = component.Properties?.GetSpdxElement(PropertyTaxonomy.HOMEPAGE);
 

--- a/tests/CycloneDX.Spdx.Interop.Tests/Resources/Spdx/v2.3/document.json
+++ b/tests/CycloneDX.Spdx.Interop.Tests/Resources/Spdx/v2.3/document.json
@@ -186,7 +186,6 @@
       "licenseDeclared": "NOASSERTION",
       "name": "Jena",
       "primaryPackagePurpose": "APPLICATION",
-      "purl": "pkg:maven/org.apache.jena/apache-jena@3.12.0",
       "versionInfo": "3.12.0"
     },
     {

--- a/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromCDXToSpdxTest_bom.snap
+++ b/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromCDXToSpdxTest_bom.snap
@@ -34,6 +34,13 @@
         }
       ],
       "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:npm/acme/component@1.0.0",
+          "referenceType": "purl"
+        }
+      ],
       "licenseDeclared": "Apache-2.0",
       "name": "tomcat-catalina",
       "primaryPackagePurpose": "LIBRARY",

--- a/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromCDXToSpdxTest_compositions.snap
+++ b/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromCDXToSpdxTest_compositions.snap
@@ -12,6 +12,13 @@
     {
       "SPDXID": "SPDXRef-pkg:maven/partner/shaded-library@1.0",
       "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:maven/partner/shaded-library@1.0",
+          "referenceType": "purl"
+        }
+      ],
       "name": "Partner Shaded Library",
       "primaryPackagePurpose": "LIBRARY",
       "versionInfo": "1.0"
@@ -19,6 +26,13 @@
     {
       "SPDXID": "SPDXRef-Package-2",
       "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:maven/acme/library@3.0",
+          "referenceType": "purl"
+        }
+      ],
       "name": "Acme Library",
       "primaryPackagePurpose": "LIBRARY",
       "versionInfo": "3.0"

--- a/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromCDXToSpdxTest_evidence.snap
+++ b/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromCDXToSpdxTest_evidence.snap
@@ -18,6 +18,13 @@
         "Copyright (C) 2004,2005 University of Maryland"
       ],
       "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:maven/com.google.code.findbugs/findbugs-project@3.0.0",
+          "referenceType": "purl"
+        }
+      ],
       "licenseDeclared": "LGPL-3.0-or-later",
       "licenseInfoFromFiles": [
         "Apache-2.0",

--- a/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromCDXToSpdxTest_service.snap
+++ b/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromCDXToSpdxTest_service.snap
@@ -18,6 +18,13 @@
         }
       ],
       "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:maven/com.acme/stock-java-client@1.0.12",
+          "referenceType": "purl"
+        }
+      ],
       "licenseDeclared": "Apache-2.0",
       "name": "stock-java-client",
       "primaryPackagePurpose": "LIBRARY",

--- a/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromCDXToSpdxToCDXRoundTripTest_bom.snap
+++ b/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromCDXToSpdxToCDXRoundTripTest_bom.snap
@@ -66,6 +66,7 @@
           "expression": "Apache-2.0"
         }
       ],
+      "purl": "pkg:npm/acme/component@1.0.0",
       "externalReferences": [
         {
           "url": "NOASSERTION",

--- a/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromCDXToSpdxToCDXRoundTripTest_compositions.snap
+++ b/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromCDXToSpdxToCDXRoundTripTest_compositions.snap
@@ -34,6 +34,7 @@
       "licenses": [
         {}
       ],
+      "purl": "pkg:maven/partner/shaded-library@1.0",
       "externalReferences": [
         {
           "url": "NOASSERTION",
@@ -58,6 +59,7 @@
       "licenses": [
         {}
       ],
+      "purl": "pkg:maven/acme/library@3.0",
       "externalReferences": [
         {
           "url": "NOASSERTION",

--- a/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromCDXToSpdxToCDXRoundTripTest_evidence.snap
+++ b/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromCDXToSpdxToCDXRoundTripTest_evidence.snap
@@ -36,6 +36,7 @@
           "expression": "LGPL-3.0-or-later"
         }
       ],
+      "purl": "pkg:maven/com.google.code.findbugs/findbugs-project@3.0.0",
       "externalReferences": [
         {
           "url": "NOASSERTION",

--- a/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromCDXToSpdxToCDXRoundTripTest_service.snap
+++ b/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromCDXToSpdxToCDXRoundTripTest_service.snap
@@ -42,6 +42,7 @@
           "expression": "Apache-2.0"
         }
       ],
+      "purl": "pkg:maven/com.acme/stock-java-client@1.0.12",
       "externalReferences": [
         {
           "url": "NOASSERTION",

--- a/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromSpdxToCDXTest_v2.2document.snap
+++ b/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromSpdxToCDXTest_v2.2document.snap
@@ -297,10 +297,6 @@
           "value": "NOASSERTION"
         },
         {
-          "name": "spdx:external-reference:package-manager:purl",
-          "value": "pkg:maven/org.apache.jena/apache-jena@3.12.0"
-        },
-        {
           "name": "spdx:download-location",
           "value": "https://search.maven.org/remotecontent?filepath=org/apache/jena/apache-jena/3.12.0/apache-jena-3.12.0.tar.gz"
         },

--- a/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromSpdxToCDXTest_v2.3document.snap
+++ b/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromSpdxToCDXTest_v2.3document.snap
@@ -305,10 +305,6 @@
           "value": "NOASSERTION"
         },
         {
-          "name": "spdx:external-reference:package-manager:purl",
-          "value": "pkg:maven/org.apache.jena/apache-jena@3.12.0"
-        },
-        {
           "name": "spdx:download-location",
           "value": "https://search.maven.org/remotecontent?filepath=org/apache/jena/apache-jena/3.12.0/apache-jena-3.12.0.tar.gz"
         }


### PR DESCRIPTION
This (partly, depending if the request for `cpe` in a comment is considered) addresses https://github.com/CycloneDX/cyclonedx-cli/issues/424.

