### PR TITLE
Fix json serialization of rating

### DIFF
--- a/src/CycloneDX.Core/Models/Vulnerabilities/Rating.cs
+++ b/src/CycloneDX.Core/Models/Vulnerabilities/Rating.cs
@@ -52,6 +52,7 @@ namespace CycloneDX.Models.Vulnerabilities
         public Severity? Severity { get; set; }
 
         [XmlElement("method")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         [ProtoMember(4)]
         public ScoreMethod Method { get; set; }
         public bool ShouldSerializeMethod() { return Method != ScoreMethod.Null; }


### PR DESCRIPTION
Closes: https://github.com/CycloneDX/cyclonedx-cli/issues/409

This was missed in https://github.com/CycloneDX/cyclonedx-dotnet-library/pull/366. ShouldSerialize only applies to the xml serialization, but not for json serialization using System.Text.Json.Serialization (in contrast to for instance Newtonsoft Json serialization).