### PR TITLE
Fix SPDX checksum algorithm conversion

### DIFF
--- a/src/CycloneDX.Spdx/Serialization/JsonSerializer.cs
+++ b/src/CycloneDX.Spdx/Serialization/JsonSerializer.cs
@@ -41,6 +41,7 @@ namespace CycloneDX.Spdx.Serialization
                 
             };
             options.Converters.Add(new HyphenToUnderscoreEnumConverter<ExternalRefCategory>());
+            options.Converters.Add(new HyphenToUnderscoreEnumConverter<ChecksumAlgorithm>());
             options.Converters.Add(new JsonStringEnumConverter());
             return options;
         }

--- a/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromCDXToSpdxTest_component-hashes.snap
+++ b/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromCDXToSpdxTest_component-hashes.snap
@@ -33,27 +33,27 @@
           "checksumValue": "74a51ff45e4c11df9ba1f0094282c80489649cb157a75fa337992d2d4592a5a1b8cb4525de8db0ae25233553924d76c36e093ea7fa9df4e5b8b07fd2e074efd6"
         },
         {
-          "algorithm": "SHA3_256",
+          "algorithm": "SHA3-256",
           "checksumValue": "7478c7cf41c883a04ee89f1813f687886d53fa86f791fff90690c6221e3853aa"
         },
         {
-          "algorithm": "SHA3_384",
+          "algorithm": "SHA3-384",
           "checksumValue": "a1eea7229716487ad2ebe96b2f997a8408f32f14047994fbcc99b49012cf86c96dbd518e5d57a61b0e57dd37dd0b48f5"
         },
         {
-          "algorithm": "SHA3_512",
+          "algorithm": "SHA3-512",
           "checksumValue": "7d584825bc1767dfabe7e82b45ccb7a1119b145fa17e76b885e71429c706cef0a3171bc6575b968eec5da56a7966c02fec5402fcee55097ac01d40c550de9d20"
         },
         {
-          "algorithm": "BLAKE2b_256",
+          "algorithm": "BLAKE2b-256",
           "checksumValue": "d8779633380c050bccf4e733b763ab2abd8ad2db60b517d47fd29bbf76433237"
         },
         {
-          "algorithm": "BLAKE2b_384",
+          "algorithm": "BLAKE2b-384",
           "checksumValue": "e728ba56c2da995a559a178116c594e8bee4894a79ceb4399d8f479e5563cb1942b85936f646d14170717c576b14db7a"
         },
         {
-          "algorithm": "BLAKE2b_512",
+          "algorithm": "BLAKE2b-512",
           "checksumValue": "f8ce8d612a6c85c96cf7cebc230f6ddef26e6cedcfbc4a41c766033cc08c6ba097d1470948226807fb2d88d2a2b6fc0ff5e5440e93a603086fdd568bafcd1a9d"
         },
         {

--- a/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromSpdxToCDXToSpdxRoundTripTest_v2.3document.snap
+++ b/tests/CycloneDX.Spdx.Interop.Tests/__snapshots__/ConverterTests.FromSpdxToCDXToSpdxRoundTripTest_v2.3document.snap
@@ -76,7 +76,7 @@
       "builtDate": "2011-01-29T18:30:22Z",
       "checksums": [
         {
-          "algorithm": "BLAKE2b_512",
+          "algorithm": "BLAKE2b-512",
           "checksumValue": "624c1abb3664f4b35547e7c73864ad24"
         },
         {

--- a/tests/CycloneDX.Spdx.Tests/__snapshots__/JsonSerializerTests.JsonAsyncRoundTripTest_document-with-hyphens-in-external-reference-category.snap
+++ b/tests/CycloneDX.Spdx.Tests/__snapshots__/JsonSerializerTests.JsonAsyncRoundTripTest_document-with-hyphens-in-external-reference-category.snap
@@ -111,7 +111,7 @@
           "checksumValue": "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
         },
         {
-          "algorithm": "BLAKE2b_384",
+          "algorithm": "BLAKE2b-384",
           "checksumValue": "aaabd89c926ab525c242e6621f2f5fa73aa4afe3d9e24aed727faaadd6af38b620bdb623dd2b4788b1c8086984af8706"
         }
       ],

--- a/tests/CycloneDX.Spdx.Tests/__snapshots__/JsonSerializerTests.JsonAsyncRoundTripTest_document.snap
+++ b/tests/CycloneDX.Spdx.Tests/__snapshots__/JsonSerializerTests.JsonAsyncRoundTripTest_document.snap
@@ -111,7 +111,7 @@
           "checksumValue": "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
         },
         {
-          "algorithm": "BLAKE2b_384",
+          "algorithm": "BLAKE2b-384",
           "checksumValue": "aaabd89c926ab525c242e6621f2f5fa73aa4afe3d9e24aed727faaadd6af38b620bdb623dd2b4788b1c8086984af8706"
         }
       ],

--- a/tests/CycloneDX.Spdx.Tests/__snapshots__/JsonSerializerTests.JsonRoundTripTest_document-with-hyphens-in-external-reference-category.snap
+++ b/tests/CycloneDX.Spdx.Tests/__snapshots__/JsonSerializerTests.JsonRoundTripTest_document-with-hyphens-in-external-reference-category.snap
@@ -111,7 +111,7 @@
           "checksumValue": "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
         },
         {
-          "algorithm": "BLAKE2b_384",
+          "algorithm": "BLAKE2b-384",
           "checksumValue": "aaabd89c926ab525c242e6621f2f5fa73aa4afe3d9e24aed727faaadd6af38b620bdb623dd2b4788b1c8086984af8706"
         }
       ],

--- a/tests/CycloneDX.Spdx.Tests/__snapshots__/JsonSerializerTests.JsonRoundTripTest_document.snap
+++ b/tests/CycloneDX.Spdx.Tests/__snapshots__/JsonSerializerTests.JsonRoundTripTest_document.snap
@@ -111,7 +111,7 @@
           "checksumValue": "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
         },
         {
-          "algorithm": "BLAKE2b_384",
+          "algorithm": "BLAKE2b-384",
           "checksumValue": "aaabd89c926ab525c242e6621f2f5fa73aa4afe3d9e24aed727faaadd6af38b620bdb623dd2b4788b1c8086984af8706"
         }
       ],


### PR DESCRIPTION
Closes: https://github.com/CycloneDX/cyclonedx-dotnet-library/issues/406
(at least the first part)

According to https://spdx.github.io/spdx-spec/v2.3/package-information/#710-package-checksum-field, hyphen is used as a separator in the algorithm names, not underscore.