### PR TITLE
Fix merging vulnerabilities

### DIFF
--- a/src/CycloneDX.Utils/Merge.cs
+++ b/src/CycloneDX.Utils/Merge.cs
@@ -397,7 +397,7 @@ namespace CycloneDX.Utils
                 // vulnerabilities
                 if (bom.Vulnerabilities != null)
                 {
-                    NamespaceVulnerabilitiesRefs(ComponentBomRefNamespace(result.Metadata.Component), bom.Vulnerabilities);
+                    NamespaceVulnerabilitiesRefs(ComponentBomRefNamespace(bom.Metadata.Component), bom.Vulnerabilities);
                     result.Vulnerabilities.AddRange(bom.Vulnerabilities);
                 }
 
@@ -625,7 +625,7 @@ namespace CycloneDX.Utils
                 {
                     foreach (var affect in vulnerability.Affects)
                     {
-                        affect.Ref = bomRefNamespace;
+                        affect.Ref = NamespacedBomRef(bomRefNamespace, affect.Ref);
                     }
                 }
             }

--- a/tests/CycloneDX.Utils.Tests/__snapshots__/MergeTests.HierarchicalMergeVulnerabilitiesTest.snap
+++ b/tests/CycloneDX.Utils.Tests/__snapshots__/MergeTests.HierarchicalMergeVulnerabilitiesTest.snap
@@ -126,7 +126,7 @@
       "Analysis": null,
       "Affects": [
         {
-          "Ref": "Thing@1",
+          "Ref": "System1@1:ref1",
           "Versions": null
         }
       ]
@@ -147,7 +147,7 @@
       "Analysis": null,
       "Affects": [
         {
-          "Ref": "Thing@1",
+          "Ref": "System2@1:ref2",
           "Versions": null
         }
       ]


### PR DESCRIPTION
Addresses: https://github.com/CycloneDX/cyclonedx-cli/issues/471

Preserve the `affect.Ref` property of vulnerabilities in a hierarchical merge.