### PR TITLE
Optimize JSON serialization performance

### DIFF
--- a/benchmark/Benchmark.csproj
+++ b/benchmark/Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/benchmark/Program.cs
+++ b/benchmark/Program.cs
@@ -25,6 +25,7 @@ using CycloneDX.Models;
 
 namespace CycloneDX.Core.Benchmark
 {
+    [MemoryDiagnoser]
     public class Serialization
     {
         private readonly Bom _bom;
@@ -35,10 +36,9 @@ namespace CycloneDX.Core.Benchmark
         public Serialization()
         {
             _xmlBom = File.ReadAllText(Path.Join("Resources", "valid-bom-1.4.xml"));
+            _bom = Xml.Serializer.Deserialize(_xmlBom);
             _jsonBom = Json.Serializer.Serialize(_bom);
             _protobufBom = Protobuf.Serializer.Serialize(_bom);
-
-            _bom = Xml.Serializer.Deserialize(_xmlBom);
         }
 
         [Benchmark]
@@ -98,8 +98,8 @@ namespace CycloneDX.Core.Benchmark
     {
         public static void Main(string[] args)
         {
-            // BenchmarkRunner.Run<Serialization>();
-            BenchmarkRunner.Run<Validation>();
+            var switcher = new BenchmarkSwitcher(typeof(Program).Assembly);
+            switcher.Run(args);
         }
     }
 }

--- a/src/CycloneDX.Core/Json/Converters/IdentityListConverter.cs
+++ b/src/CycloneDX.Core/Json/Converters/IdentityListConverter.cs
@@ -34,8 +34,7 @@ namespace CycloneDX.Json.Converters
         {
             if (reader.TokenType == JsonTokenType.StartObject)
             {
-                var serializerOptions = Utils.GetJsonSerializerOptions();                
-                var identity = JsonSerializer.Deserialize<EvidenceIdentity>(ref reader, serializerOptions);
+                var identity = JsonSerializer.Deserialize<EvidenceIdentity>(ref reader, options);
                 return new EvidenceIdentityList { Identities = new List<EvidenceIdentity> { identity } };
             }
             else if (reader.TokenType == JsonTokenType.StartArray)

--- a/src/CycloneDX.Core/Json/Converters/ToolChoicesConverter.cs
+++ b/src/CycloneDX.Core/Json/Converters/ToolChoicesConverter.cs
@@ -39,7 +39,7 @@ namespace CycloneDX.Json.Converters
             else if (reader.TokenType == JsonTokenType.StartObject)
             {
                 // need to remove _this_ converter from the options to prevent recursion below
-                var serializerOptions = Utils.GetJsonSerializerOptions();
+                var serializerOptions = new JsonSerializerOptions(options);
                 for (var i = 0; i < serializerOptions.Converters.Count; i++)
                 {
                     if (serializerOptions.Converters[i].CanConvert(typeof(ToolChoices)))

--- a/src/CycloneDX.Core/Json/Serializer.Deserialization.cs
+++ b/src/CycloneDX.Core/Json/Serializer.Deserialization.cs
@@ -34,7 +34,7 @@ namespace CycloneDX.Json
         public static async Task<Bom> DeserializeAsync(Stream jsonStream)
         {
             Contract.Requires(jsonStream != null);
-            return await JsonSerializer.DeserializeAsync<Bom>(jsonStream, getOption()).ConfigureAwait(false);
+            return await JsonSerializer.DeserializeAsync<Bom>(jsonStream, _options).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace CycloneDX.Json
         public static Bom Deserialize(string jsonString)
         {
             Contract.Requires(!string.IsNullOrEmpty(jsonString));
-            return JsonSerializer.Deserialize<Bom>(jsonString, getOption());
+            return JsonSerializer.Deserialize<Bom>(jsonString, _options);
         }
 
     }

--- a/src/CycloneDX.Core/Json/Serializer.Serialization.cs
+++ b/src/CycloneDX.Core/Json/Serializer.Serialization.cs
@@ -32,8 +32,13 @@ namespace CycloneDX.Json
     /// </summary>
     public static partial class Serializer
     {
-        private static readonly JsonSerializerOptions _options = Utils.GetJsonSerializerOptions();
+        private static JsonSerializerOptions _options = Utils.GetJsonSerializerOptions();
         public static JsonSerializerOptions SerializerOptionsForHash { get => _options; }
+
+        internal static void ResetSerializerOptions()
+        {
+            _options = Utils.GetJsonSerializerOptions();
+        }
 
         /// <summary>
         /// Serializes a CycloneDX BOM writing the output to a stream.

--- a/src/CycloneDX.Core/Json/Serializer.Serialization.cs
+++ b/src/CycloneDX.Core/Json/Serializer.Serialization.cs
@@ -32,10 +32,9 @@ namespace CycloneDX.Json
     /// </summary>
     public static partial class Serializer
     {
-        private static JsonSerializerOptions _optionsForHash = Utils.GetJsonSerializerOptions();
-        public static JsonSerializerOptions SerializerOptionsForHash { get => _optionsForHash; }
+        private static readonly JsonSerializerOptions _options = Utils.GetJsonSerializerOptions();
+        public static JsonSerializerOptions SerializerOptionsForHash { get => _options; }
 
-        static Func<JsonSerializerOptions> getOption = () => Utils.GetJsonSerializerOptions();        
         /// <summary>
         /// Serializes a CycloneDX BOM writing the output to a stream.
         /// </summary>
@@ -45,7 +44,7 @@ namespace CycloneDX.Json
         public static async Task SerializeAsync(Bom bom, Stream outputStream)
         {            
             Contract.Requires(bom != null && outputStream != null);
-            await JsonSerializer.SerializeAsync<Bom>(outputStream, BomUtils.GetBomForSerialization(bom), getOption()).ConfigureAwait(false);
+            await JsonSerializer.SerializeAsync<Bom>(outputStream, BomUtils.GetBomForSerialization(bom), _options).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -56,80 +55,80 @@ namespace CycloneDX.Json
         public static string Serialize(Bom bom)
         {
             Contract.Requires(bom != null);
-            var jsonBom = JsonSerializer.Serialize(BomUtils.GetBomForSerialization(bom), getOption());
+            var jsonBom = JsonSerializer.Serialize(BomUtils.GetBomForSerialization(bom), _options);
             return jsonBom;
         }
 
         internal static string Serialize(Component component)
         {
             Contract.Requires(component != null);
-            return JsonSerializer.Serialize(component, getOption());
+            return JsonSerializer.Serialize(component, _options);
         }
 
         internal static string Serialize(Dependency dependency)
         {
             Contract.Requires(dependency != null);
-            return JsonSerializer.Serialize(dependency, getOption());
+            return JsonSerializer.Serialize(dependency, _options);
         }
 
         internal static string Serialize(Service service)
         {
             Contract.Requires(service != null);
-            return JsonSerializer.Serialize(service, getOption());
+            return JsonSerializer.Serialize(service, _options);
         }
 
         #pragma warning disable 618
         internal static string Serialize(Tool tool)
         {
             Contract.Requires(tool != null);
-            return JsonSerializer.Serialize(tool, getOption());
+            return JsonSerializer.Serialize(tool, _options);
         }
         #pragma warning restore 618
 
         internal static string Serialize(Models.Vulnerabilities.Vulnerability vulnerability)
         {
             Contract.Requires(vulnerability != null);
-            return JsonSerializer.Serialize(vulnerability, getOption());
+            return JsonSerializer.Serialize(vulnerability, _options);
         }
 
         internal static string Serialize(Models.Composition composition)
         {
             Contract.Requires(composition != null);
-            return JsonSerializer.Serialize(composition, getOption());
+            return JsonSerializer.Serialize(composition, _options);
         }
 
         internal static string Serialize(Models.ExternalReference externalReference)
         {
             Contract.Requires(externalReference != null);
-            return JsonSerializer.Serialize(externalReference, getOption());
+            return JsonSerializer.Serialize(externalReference, _options);
         }
 
         internal static string Serialize(Models.Standard standard)
         {
             Contract.Requires(standard != null);
-            return JsonSerializer.Serialize(standard, getOption());
+            return JsonSerializer.Serialize(standard, _options);
         }
 
         internal static string Serialize(Models.OrganizationalEntity organization)
         {
             Contract.Requires(organization != null);
-            return JsonSerializer.Serialize(organization, getOption());
+            return JsonSerializer.Serialize(organization, _options);
         }
 
         internal static string Serialize(Models.Claim obj)
         {
             Contract.Requires(obj != null);
-            return JsonSerializer.Serialize(obj, getOption());
+            return JsonSerializer.Serialize(obj, _options);
         }
         internal static string Serialize(Models.Assessor obj)
         {
             Contract.Requires(obj != null);
-            return JsonSerializer.Serialize(obj, getOption());
+            return JsonSerializer.Serialize(obj, _options);
         }
         internal static string Serialize(Models.Attestation obj)
         {
             Contract.Requires(obj != null);
-            return JsonSerializer.Serialize(obj, getOption());
+            return JsonSerializer.Serialize(obj, _options);
         }
     }
 }

--- a/src/CycloneDX.Core/Json/Utils.cs
+++ b/src/CycloneDX.Core/Json/Utils.cs
@@ -30,7 +30,7 @@ namespace CycloneDX.Json
     /// </summary>
     public static class Utils
     {
-        private static bool useUnsafeRelaxedJsonEscaping = false;
+        private static bool useUnsafeRelaxedJsonEscaping;
 
         public static bool UseUnsafeRelaxedJsonEscaping
         {

--- a/src/CycloneDX.Core/Json/Utils.cs
+++ b/src/CycloneDX.Core/Json/Utils.cs
@@ -17,6 +17,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using CycloneDX.Core.Models;
 using CycloneDX.Json.Converters;
 using CycloneDX.Models;
@@ -29,7 +30,21 @@ namespace CycloneDX.Json
     /// </summary>
     public static class Utils
     {
-        public static bool UseUnsafeRelaxedJsonEscaping { get; set; } = false;  
+        private static bool useUnsafeRelaxedJsonEscaping = false;
+
+        public static bool UseUnsafeRelaxedJsonEscaping
+        {
+            get
+            {
+                return useUnsafeRelaxedJsonEscaping;
+            }
+            set
+            {
+                useUnsafeRelaxedJsonEscaping = value;
+                Serializer.ResetSerializerOptions();
+            }
+        }
+
         public static JsonSerializerOptions GetBaseJsonSerializerOptions()
         {
             return new JsonSerializerOptions


### PR DESCRIPTION
The JSON serializer currently recreates the JsonSerializerOptions every time, which is a huge waste of ressources since the options act as a cache for the serialization metadata.

This changes the serializer to keep the options in a static field instead.

Also some benchmark fixes:
- fix TargetFramework
- add [MemoryAnalyzer]
- fix NullReference
- use BenchmarkSwitcher so use can filter with command line args

Results can be reproduced with:

```
dotnet run --project benchmark/ --configuration Release -- --filter "*erializeJson*"
```

Before:

|          Method |     Mean |     Error |    StdDev |    Gen 0 |    Gen 1 | Allocated |
|---------------- |---------:|----------:|----------:|---------:|---------:|----------:|
|   SerializeJson | 7.044 ms | 0.0682 ms | 0.0638 ms | 703.1250 | 187.5000 |     11 MB |
| DeserializeJson | 6.973 ms | 0.1071 ms | 0.1002 ms | 703.1250 | 140.6250 |     11 MB |

After:

|          Method |     Mean |    Error |   StdDev |   Gen 0 |  Gen 1 | Allocated |
|---------------- |---------:|---------:|---------:|--------:|-------:|----------:|
|   SerializeJson | 24.48 us | 0.085 us | 0.071 us | 10.8643 | 5.3711 |    178 KB |
| DeserializeJson | 12.86 us | 0.034 us | 0.030 us |  2.9297 | 0.9003 |     48 KB |